### PR TITLE
Update broken dependency

### DIFF
--- a/goiv_fb.go
+++ b/goiv_fb.go
@@ -9,7 +9,7 @@ import (
 	"image/draw"
 	"os"
 
-	"github.com/gen2brain/framebuffer"
+	"github.com/maugsburger/framebuffer"
 	"github.com/pkg/term"
 )
 


### PR DESCRIPTION
See https://github.com/jteeuwen/discussions/issues/3 . 

Currently go build doesn't work.

```
$ GOPATH=/home/sarnobat/gopath/ /home/sarnobat/trash/go/bin/go build                                           /home/sarnobat/trash/goiv
goiv_fb.go:12:2: no required module provides package github.com/jteeuwen/framebuffer; to add it:
	go get github.com/jteeuwen/framebuffer
```